### PR TITLE
Fixed: Don't dispose of controller passed in.

### DIFF
--- a/lib/markdown_text_input.dart
+++ b/lib/markdown_text_input.dart
@@ -84,7 +84,7 @@ class _MarkdownTextInputState extends State<MarkdownTextInput> {
 
   @override
   void dispose() {
-    _controller.dispose();
+    if (widget.controller == null) _controller.dispose();
     super.dispose();
   }
 


### PR DESCRIPTION
This is the responsibility of the parent.  Our app was crashing when this widget was scrolled off the screen and back.  The controller was disposed.