### PR TITLE
Making sure that text selection bounds are from lower to upper

### DIFF
--- a/lib/markdown_text_input.dart
+++ b/lib/markdown_text_input.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:math';
 import 'dart:ui';
 
 import 'package:expandable/expandable.dart';
@@ -75,8 +76,8 @@ class _MarkdownTextInputState extends State<MarkdownTextInput> {
     final basePosition = textSelection.baseOffset;
     var noTextSelected = (textSelection.baseOffset - textSelection.extentOffset) == 0;
 
-    var fromIndex = textSelection.baseOffset;
-    var toIndex = textSelection.extentOffset;
+    var fromIndex = min(textSelection.baseOffset, textSelection.extentOffset);
+    var toIndex = max(textSelection.extentOffset, textSelection.baseOffset);
 
     final result = FormatMarkdown.convertToMarkdown(type, _controller.text, fromIndex, toIndex,
         titleSize: titleSize, link: link, selectedText: selectedText ?? _controller.text.substring(fromIndex, toIndex));


### PR DESCRIPTION
on Web, if you select from right to left and apply a markdown modification (like Bold) you get an error about selection out of bounds.

This PR fixes it by making sure the changes applied are from the initial index to the end index of the string based on the minimum and maximum between the base and extend offsets of the selection.